### PR TITLE
Add a filter so other plugins can customize the message sent to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Easy Digital Downloads - Slack Notifications #
+
+**NOTE** This is my fork of the nice tubiz plugin. I forked it planning to add more options for customize the message sent to Slack. Garubi
+
+
 **Contributors:** tubiz
 
 **Donate link:** http://bosun.me/donate

--- a/edd-slack-notifications.php
+++ b/edd-slack-notifications.php
@@ -136,6 +136,8 @@ function tbz_edd_notify_slack( $payment_id ){
     $message .= "\n *Order Total:* $curreny_symbol$order_amount \n";
     $message .= "*Payment Method:* $payment_method \n";
 
+    $message = apply_filters('tbz_edd_message', $payment_id);
+
     $attachment = array();
 
     $attachment[] = array(


### PR DESCRIPTION
Hi!
I have added a filter on the message sent to slack, so if someone need, he can hook in and customize the message.

The filter take 2 arguments: $payment_id and $message.

For example one can add the customer details with a very  simple plugin like:

``` php
add_filter('tbz_edd_message','garubi_extend_slack_message',10,2);
function garubi_extend_slack_message($payment_id, $message){
    $payment_meta   = edd_get_payment_meta( $payment_id );
    $user_data = $payment_meta['user_info'];
    $message .= '*Customer:* '.$user_data['first_name'].' '.$user_data['last_name'].' '.$user_data['email']."\n";
    return $message;
}
```

I think that this is a little change that can add a lot to the plugin, do you mind adding it to the official released version?

Stefano

p.s.
This is my first pull request ever... I hope it's all right ;-)
